### PR TITLE
Change to gratis license

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -5,7 +5,7 @@ cask :v1 => 'amazon-music' do
   url 'https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/20141015/224318ebff/AmazonMusicInstaller.dmg'
   name 'Amazon Music'
   homepage 'https://www.amazon.com/gp/feature.html/ref=dm_mo_cpw_fb_lm?docId=1001067901'
-  license :commercial
+  license :gratis
 
   installer :manual => 'Amazon Music Installer.app'
 end


### PR DESCRIPTION
As [per discussion](https://github.com/caskroom/homebrew-cask/pull/9737#issuecomment-75617191) with @Amorymeltzer, this is the more appropriate license -- the binary is still free.
